### PR TITLE
Hot fix/various fixes

### DIFF
--- a/src/middlewares/validation_schemas/account.ts
+++ b/src/middlewares/validation_schemas/account.ts
@@ -9,6 +9,7 @@ export const createAccountBodySchema = z
 
 export const updateAccountBodySchema = z
   .object({
+    id: z.string().optional(),
     name: z.string(),
     currencyId: z.number(),
   })

--- a/src/middlewares/validation_schemas/category.ts
+++ b/src/middlewares/validation_schemas/category.ts
@@ -8,6 +8,7 @@ export const createCategoryBodySchema = z
 
 export const updateCategoryBodySchema = z
   .object({
+    id: z.string().optional(),
     name: z.string(),
   })
   .strict();

--- a/src/middlewares/validation_schemas/transaction.ts
+++ b/src/middlewares/validation_schemas/transaction.ts
@@ -18,6 +18,7 @@ export const createTransactionBodySchema = z
 
 export const updateTransactionBodySchema = z
   .object({
+    id: z.string().optional(),
     amount: z.number(),
     description: z.string(),
     date: z.string(),


### PR DESCRIPTION
This pull request includes changes to the validation schemas for account, category, and transaction updates. The main focus is to make the `id` field optional in these schemas.

Validation schema updates:

* [`src/middlewares/validation_schemas/account.ts`](diffhunk://#diff-4a0d590ad335df5d08a5ac5936a7974a6e98ba537f449f9c5114117362d60617R12): Added the `id` field as an optional string in `updateAccountBodySchema`.
* [`src/middlewares/validation_schemas/category.ts`](diffhunk://#diff-45b5c5f06fef25d56ca6a74aa3b444203e573f67f35af068bd3c8fe285d8034fR11): Added the `id` field as an optional string in `updateCategoryBodySchema`.
* [`src/middlewares/validation_schemas/transaction.ts`](diffhunk://#diff-3b986980c17147de4ea90a00eba322f851534f87e9801e7e8124e31ae06eb436R21): Added the `id` field as an optional string in `updateTransactionBodySchema`.