### PR TITLE
1.3.1 Hot-Fix: Default order by date transaction

### DIFF
--- a/src/services/transaction.ts
+++ b/src/services/transaction.ts
@@ -8,8 +8,6 @@ import {
 import {
   CreateTransactionInput,
   FilterTransactionsInput,
-  OrderByDirections,
-  OrderByFields,
   OrderByItem,
 } from '../types/transaction';
 import { ParsedQs } from 'qs';
@@ -96,14 +94,15 @@ export function formatGetTransactionsFilters(
     type: type ? Number(type as string) : defaultFilters.type,
     accountId: accountId ? (accountId as string) : defaultFilters.accountId,
     categoryId: categoryId ? (categoryId as string) : defaultFilters.categoryId,
-    orderBy: orderBy
-      ? String(orderBy)
-          .split(',')
-          .map((clause) => {
-            const [field, direction] = clause.split(':');
-            return { field, direction } as OrderByItem;
-          })
-      : defaultFilters.orderBy,
+    orderBy:
+      orderBy && String(orderBy) !== ''
+        ? String(orderBy)
+            .split(',')
+            .map((clause) => {
+              const [field, direction] = clause.split(':');
+              return { field, direction } as OrderByItem;
+            })
+        : defaultFilters.orderBy,
     limit: limit ? Number(limit) : defaultFilters.limit,
     offset: offset ? Number(offset) : defaultFilters.offset,
   };


### PR DESCRIPTION
This pull request includes changes to the `src/services/transaction.ts` file to clean up imports and fix the formatting of transaction filters.

Code cleanup:

* [`src/services/transaction.ts`](diffhunk://#diff-c69299e8c418dcefed9c4114412c428323e0060b87a31d3e8c6b3d5b92db8057L11-L12): Removed unused imports `OrderByDirections` and `OrderByFields` from the transaction types.

Fix to transaction filters:

* [`src/services/transaction.ts`](diffhunk://#diff-c69299e8c418dcefed9c4114412c428323e0060b87a31d3e8c6b3d5b92db8057L99-R98): Fix the `orderBy` formatting logic in the `formatGetTransactionsFilters` function to handle empty orderBy.