### PR TITLE
1.4.1 Hotfix amount display for accounts and categories

### DIFF
--- a/src/repository/account.ts
+++ b/src/repository/account.ts
@@ -4,6 +4,7 @@ import {
   CreateAccountInput,
 } from '../types/account';
 import { prisma } from '../../prisma/client';
+import { formatAmountForDisplay } from '../utils/amount';
 
 export async function createAccountDB(
   account: CreateAccountInput,
@@ -110,7 +111,7 @@ export async function getAccountsByUserWithBalanceDB(
     userId: account.userId,
     createdAt: account.createdAt,
     updatedAt: account.updatedAt,
-    balance: account.balance,
+    balance: formatAmountForDisplay(account.balance),
     currency: {
       id: account.currencyId,
       name: account.currencyName,

--- a/src/repository/category.ts
+++ b/src/repository/category.ts
@@ -5,6 +5,7 @@ import {
   CreateCategoryInput,
 } from '../types/category';
 import { prisma } from '../../prisma/client';
+import { formatAmountForDisplay } from '../utils/amount';
 
 export async function createCategoryDB(
   category: CreateCategoryInput,
@@ -86,7 +87,14 @@ export async function getCategoriesByUserWithBalanceDB({
     GROUP BY
       c.id;
   `;
-  return categoriesWithBalance;
+  return categoriesWithBalance.map((category) => ({
+    id: category.id,
+    name: category.name,
+    userId: category.userId,
+    createdAt: category.createdAt,
+    updatedAt: category.updatedAt,
+    balance: formatAmountForDisplay(category.balance),
+  }));
 }
 
 export async function getCategoryByIdDB(


### PR DESCRIPTION
This pull request standardizes the formatting of balance amounts returned by the account and category repository functions. Now, balances are consistently formatted for display before being returned from the database access layer.

**Balance formatting improvements:**

* Updated `getAccountsByUserWithBalanceDB` in `src/repository/account.ts` to apply `formatAmountForDisplay` to the `balance` field before returning account data.
* Updated `getCategoriesByUserWithBalanceDB` in `src/repository/category.ts` to map and format the `balance` field for each category using `formatAmountForDisplay`.

**Codebase consistency:**

* Imported `formatAmountForDisplay` from `../utils/amount` in both `src/repository/account.ts` and `src/repository/category.ts` to support the new formatting logic. [[1]](diffhunk://#diff-8e616f28370ada29f0e9c6668d563da3fb10da36abddc023a815af5ff57f566cR7) [[2]](diffhunk://#diff-1b815051c4c60d7c3daa1ff2e01e97da3a3100d9873a1224c8599b1d4bc84e93R8)…d category retrieval functions