### PR TITLE
1.4.2 Hotfix update default transaction ordering

### DIFF
--- a/src/services/transaction.ts
+++ b/src/services/transaction.ts
@@ -131,6 +131,10 @@ export async function formatGetTransactionsFilters(
         field: OrderByFields.Date,
         direction: OrderByDirections.Desc,
       },
+      {
+        field: OrderByFields.CreatedAt,
+        direction: OrderByDirections.Desc,
+      },
     ],
     limit: 20,
     offset: 0,

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -42,6 +42,7 @@ export enum OrderByDirections {
 export enum OrderByFields {
   Date = 'date',
   Amount = 'amount',
+  CreatedAt = 'createdAt',
 }
 
 export interface CreateTransactionInput {


### PR DESCRIPTION
This pull request adds support for ordering transactions by their creation date in addition to the existing date field. The changes update both the transaction filter logic and the relevant type definitions.

Ordering enhancements:
* Added `CreatedAt` as a new field to the `OrderByFields` enum in `src/types/transaction.ts`, allowing transactions to be sorted by their creation timestamp.
* Updated the default ordering logic in `formatGetTransactionsFilters` to include sorting by `CreatedAt` in descending order, after sorting by `Date`